### PR TITLE
Implement pair wise iso lens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ Copyright 2012 Dmitry Kolesnikov
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+

--- a/src/datum.app.src
+++ b/src/datum.app.src
@@ -1,7 +1,7 @@
 {application, datum,
    [
       {description, "pure functional and generic programming"},
-      {vsn,         "4.3.5"},
+      {vsn,         "4.3.6"},
       {modules,     []},
       {registered,  []},
       {applications,[

--- a/src/lens/lens.erl
+++ b/src/lens/lens.erl
@@ -122,6 +122,10 @@ iso(LensA, A, LensB, B) ->
 iso(Lenses) ->
    {lens:p([A || {A, _} <- Lenses]), lens:p([B || {_, B} <- Lenses])}.
 
+iso(LensesA, LensesB)
+ when is_list(LensesA), is_list(LensesB) ->
+   {lens:p(LensesA), lens:p(LensesB)}.
+
 
 %%
 %% applies forward isomorphism from A to B
@@ -152,20 +156,6 @@ apply(Ln, Fun, S) ->
    erlang:tl( Ln(fun(X) -> fmap(Fun, with_id(X)) end, S) ).
 
 
-%%
-%% Use lens:iso/4
- -spec iso(lens(), lens()) -> {_, _}.
-
-iso(LensesA, LensesB)
- when is_list(LensesA), is_list(LensesB) ->
-   iso(lens:p(LensesA), lens:p(LensesB));
-iso(LensesA, LensesB) ->
-   {morphism(LensesA, LensesB), morphism(LensesB, LensesA)}.
-
-morphism(LensesA, LensesB) ->
-   fun(Source, Target) ->
-      lens:put(LensesB, lens:get(LensesA, Source), Target)
-   end.
 
 
 %%%------------------------------------------------------------------

--- a/src/lens/lens.erl
+++ b/src/lens/lens.erl
@@ -24,7 +24,7 @@
 
 %%
 %% lens primitives
--export([fmap/2, apply/3, map/3, get/2, put/3, iso/2, isof/3, isob/3, iso/4]). 
+-export([fmap/2, apply/3, map/3, get/2, put/3, iso/2, iso/1, isof/3, isob/3, iso/4]). 
 
 %%
 %% lenses
@@ -115,6 +115,28 @@ put(Ln, A, S) ->
 iso(LensA, A, LensB, B) ->
    lens:put(LensB, lens:get(LensA, A), B).
 
+%%
+%% helper function of lens pairs product combinator
+-spec iso([{lens(), lens()}]) -> {lens(), lens()}.
+
+iso(Lenses) ->
+   {lens:p([A || {A, _} <- Lenses]), lens:p([B || {_, B} <- Lenses])}.
+
+
+%%
+%% applies forward isomorphism from A to B
+-spec isof({_, _}, _, _) -> _.
+
+isof({LensA, LensB}, A, B) ->
+   iso(LensA, A, LensB, B).
+
+%%
+%% applies backward isomorphism from B to A
+-spec isob({_, _}, _, _) -> _.
+
+isob({LensA, LensB}, B, A) ->
+   iso(LensB, B, LensA, A).
+
 
 %%%------------------------------------------------------------------
 %%%
@@ -145,19 +167,6 @@ morphism(LensesA, LensesB) ->
       lens:put(LensesB, lens:get(LensesA, Source), Target)
    end.
 
-%%
-%% applies forward isomorphism from A to B
--spec isof({_, _}, _, _) -> _.
-
-isof({Iso, _}, A, B) ->
-   Iso(A, B).
-
-%%
-%% applies backward isomorphism from B to A
--spec isob({_, _}, _, _) -> _.
-
-isob({_, Iso}, A, B) ->
-   Iso(A, B).
 
 %%%------------------------------------------------------------------
 %%%

--- a/test/lens_SUITE.erl
+++ b/test/lens_SUITE.erl
@@ -641,16 +641,16 @@ apply(_Config) ->
 -record(user,    {name = undefined, address = #address{}}).
 
 iso(_Config) ->
-   Iso = lens:iso(
-      [
-         lens:ti(#user.name),
-         lens:c(lens:ti(#user.address), lens:ti(#address.street))
-      ], 
-      [
-         lens:at(name),
+   Iso = lens:iso([
+      {
+         lens:ti(#user.name), 
+         lens:at(name)
+      },
+      {
+         lens:c(lens:ti(#user.address), lens:ti(#address.street)),
          lens:c(lens:at(address, #{}), lens:at(street))
-      ]
-   ),
+      }
+   ]),
    Rec = #user{name = "Verner", address = #address{street = "Blumenstraße"}},
    Map = #{name => "Verner", address => #{street => "Blumenstraße"}},
 

--- a/test/lens_SUITE.erl
+++ b/test/lens_SUITE.erl
@@ -97,7 +97,8 @@
    put/1,
    map/1,
    apply/1,
-   iso/1,
+   iso_pairs/1,
+   iso_lists/1,
    iso4/1
 ]).
 
@@ -151,7 +152,7 @@ groups() ->
           product1, product2, product3, product4, product5, product6, product7, product8, product9]},
 
       {lens_api, [parallel],
-         [get, put, map, apply, iso, iso4]}
+         [get, put, map, apply, iso_pairs, iso_lists, iso4]}
    ].
 
 %%%----------------------------------------------------------------------------   
@@ -640,7 +641,7 @@ apply(_Config) ->
 -record(address, {street = undefined}).
 -record(user,    {name = undefined, address = #address{}}).
 
-iso(_Config) ->
+iso_pairs(_Config) ->
    Iso = lens:iso([
       {
          lens:ti(#user.name), 
@@ -656,6 +657,24 @@ iso(_Config) ->
 
    Map = lens:isof(Iso, Rec, #{}),
    Rec = lens:isob(Iso, Map, #user{}).
+
+iso_lists(_Config) ->
+   Iso = lens:iso(
+      [
+         lens:ti(#user.name),
+         lens:c(lens:ti(#user.address), lens:ti(#address.street))
+      ], 
+      [
+         lens:at(name),
+         lens:c(lens:at(address, #{}), lens:at(street))
+      ]
+   ),
+   Rec = #user{name = "Verner", address = #address{street = "Blumenstraße"}},
+   Map = #{name => "Verner", address => #{street => "Blumenstraße"}},
+
+   Map = lens:isof(Iso, Rec, #{}),
+   Rec = lens:isob(Iso, Map, #user{}).
+
 
 %%
 %%
@@ -677,5 +696,3 @@ iso4(_Config) ->
 
    Map = lens:iso(iso_rec_name_street(), Rec, iso_map_name_street(), #{}),
    Rec = lens:iso(iso_map_name_street(), Map, iso_rec_name_street(), #user{}).
-
-


### PR DESCRIPTION
The abstract view is easy to deal with (`lens:p`). However, it is hard
to maintain when you need to stich data structures together. Therefore
pair-wise lens `[{lens(), lens()}]` is compromise for two separate
lists `[lens()]`, `[lens()]`. It targets practical data transformation
applications.