### PR TITLE
Remove non-existing erl_first_files

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,9 +13,6 @@
 ,  "src/category/datum_cat_reader.erl"
 ,  "src/category/datum_cat_kleisli.erl"
 
-,  "src/monad/monad.erl"
-,  "src/monad/datum_monad.erl"
-
 ,  "src/partial.erl"
 
 ,  "src/foldable.erl"


### PR DESCRIPTION
This fixes a compilation error when used with erlang.mk.