### PR TITLE
Fixed error in rebar3 compile

### DIFF
--- a/src/maplike/heap.erl
+++ b/src/maplike/heap.erl
@@ -66,6 +66,8 @@
    remove/2
 ]).
 
+-export_type([heap/0, rank/0]).
+
 -type heap()  :: datum:option({heap(), rank(), key(), val(), heap()}).
 -type key()   :: _.
 -type val()   :: _.

--- a/src/maplike/htree.erl
+++ b/src/maplike/htree.erl
@@ -52,6 +52,8 @@
 -define(CONFIG_HTREE_WIDTH,     2).
 -endif.
 
+-export_type([inner/0, tree/0, leaf/0]).
+
 %%
 %% data types
 -type(leaf()     :: [{key(), val()}]).   %% leaf node container


### PR DESCRIPTION
Fixed error in rebar3 compile

datum >
rebar3 compile
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling datum
===> Compiling src/maplike/heap.erl failed
src/maplike/heap.erl:69:2: type heap() is unused
src/maplike/heap.erl:72:2: type rank() is unused

erl --version
Erlang/OTP 25 [erts-13.2.2.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit] [dtrace]

